### PR TITLE
Updating guava and junit to fix security issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /target/
 /.idea/
-/SBDE-client-reference-App-Redesign.iml
+/*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,10 @@
             <okhttp-version>2.7.5</okhttp-version>
             <gson-version>2.8.1</gson-version>
             <threetenbp-version>1.3.5</threetenbp-version>
-            <junit-version>4.12</junit-version>
+            <junit-version>4.13.2</junit-version>
             <mockito-version>1.10.19</mockito-version>
-            <oauth1-signer-version> 1.2.3</oauth1-signer-version>
-            <guava-version>29.0-jre</guava-version>
+            <oauth1-signer-version>1.2.3</oauth1-signer-version>
+            <guava-version>31.0.1-jre</guava-version>
 
         </properties>
 


### PR DESCRIPTION
Bumping Junit version for CVE-2020-15250 and Guava version for CVE-2020-8908.